### PR TITLE
[DENG-11101] Move generated DAGs to private-bigquery-etl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "bigquery-etl"]
+[submodule "private-bigquery-etl-dags"]
 	path = bigquery-etl
 	url = git@github.com:mozilla/private-bigquery-etl.git
 	branch = generated-dags

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "bigquery-etl"]
 	path = bigquery-etl
-	url = git@github.com:mozilla/bigquery-etl.git
+	url = git@github.com:mozilla/private-bigquery-etl.git
+	branch = generated-dags
 [submodule "telemetry-airflow"]
 	path = telemetry-airflow
 	url = git@github.com:mozilla/telemetry-airflow.git


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-11101

Generated DAGs will no longer be pushed to bigquery-etl as they might contain references to sensitive/private Airflow tasks that could reveal partner names. Generated DAGs now live in private-bigquery-etl only, so the submodule reference needs to be updated.

Depends on https://github.com/mozilla/bigquery-etl/pull/9459. Merge after.